### PR TITLE
Drop NodeJS 0.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "6"
 before_script:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "main": "Gruntfile.js",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4.2.0"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Following https://github.com/morishitter/stylefmt/pull/191/files, `grunt-stylefmt` should also drop support for NodeJS 0.12.x
