### PR TITLE
issue#5 fix

### DIFF
--- a/tasks/stylefmt.js
+++ b/tasks/stylefmt.js
@@ -3,6 +3,9 @@ module.exports = function (grunt) {
   var stylefmt = require('stylefmt');
 
   grunt.registerMultiTask('stylefmt', 'Grunt plugin for stylefmt', function () {
+    var done = this.async(),
+        options = this.options();
+    
     this.files.forEach(function (file) {
       var src = file.src.filter(function (filepath) {
         if (!grunt.file.exists(filepath)) {
@@ -13,9 +16,13 @@ module.exports = function (grunt) {
         }
       }).map(function (filepath) {
         var cssFile = grunt.file.read(filepath);
-        stylefmt.process(cssFile).then(function (result) {
+        stylefmt.process(cssFile, options).then(function (result) {
           grunt.file.write(file.dest, result.css);
           grunt.log.writeln('File "' + file.dest + '" created.');
+          done();
+        }, function(error) {
+          grunt.log.error(error);
+          done(error);
         });
       });    
     });


### PR DESCRIPTION
1) The task completes asynchronously once `stylefmt` completes processing (either creates new file or outputs processing error).
2) Added an ability to set `stylefmt` options in `grunt.initConfig({stylefmt: {options:{...}}})`.